### PR TITLE
Bugfix @reffect/react

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ cache:
 install:
   - npm i
 
+jobs:
+  include:
+    - stage: size
+      script:
+        - npm run size
+
 notifications:
   slack:
     rooms:

--- a/packages/react/.size-limit.json
+++ b/packages/react/.size-limit.json
@@ -12,6 +12,6 @@
   {
     "path": "reffect-react.umd.js",
     "webpack": false,
-    "limit": "420 B"
+    "limit": "450 B"
   }
 ]

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.1
+
+### Fixes:
+
+1. Critical bug linked with getting fresh store value from `useStore(store)`
+
 # 1.1.0
 
 ### Features:

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,10 +1,12 @@
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState, useReducer } from "react";
 import { manage, EffectState, Action } from "@reffect/core";
 
 const useIsomorphicEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
+const reducer = (state: any, newState: any) => ({ ...newState });
+
 export const useStore = <Store extends object>(store: Store): Store => {
-  const [state, setState] = useState<Store>(store);
+  const [state, setState] = useReducer(reducer, store);
 
   useIsomorphicEffect(() => manage(store).subscribe(() => setState(store)), []);
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reffect/react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React bindings for Reffect",
   "scripts": {
     "build": "node ../../build/build.js",


### PR DESCRIPTION
# 1.1.1

### Fixes:

1. Critical bug linked with getting fresh store value from `useStore(store)`
